### PR TITLE
Move back MPI Init/Finalize to within HPC Virtualization

### DIFF
--- a/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.hpp
+++ b/quantum/plugins/decorators/hpc-virtualization/hpc_virt_decorator.hpp
@@ -45,8 +45,8 @@ public:
 
   const std::string name() const override { return "hpc-virtualization"; }
   const std::string description() const override { return ""; }
-
-  ~HPCVirtDecorator() override { }
+  void finalize();
+  ~HPCVirtDecorator() override {};
 
 private:
   template <typename T>

--- a/xacc/xacc.cpp
+++ b/xacc/xacc.cpp
@@ -29,10 +29,6 @@
 #include <sys/stat.h>
 #include "TearDown.hpp"
 
-#ifdef MPI_ENABLED
-#include "mpi.h"
-#endif
-
 using namespace cxxopts;
 
 namespace xacc {
@@ -48,10 +44,6 @@ std::map<std::string, std::shared_ptr<CompositeInstruction>>
 std::map<std::string, std::shared_ptr<AcceleratorBuffer>> allocated_buffers{};
 
 std::string rootPathString = "";
-
-#ifdef MPI_ENABLED
-int isMPIInitialized;
-#endif
 
 void set_verbose(bool v) { verbose = v; }
 
@@ -112,19 +104,6 @@ void Initialize(int arc, char **arv) {
   if (!optionExists("queue-preamble")) {
     XACCLogger::instance()->dumpQueue();
   }
-
-  // Initializing MPI here
-#ifdef MPI_ENABLED
-  int provided;
-  MPI_Initialized(&isMPIInitialized);
-  if (!isMPIInitialized) {
-    MPI_Init_thread(0, NULL, MPI_THREAD_MULTIPLE, &provided);
-    if (provided != MPI_THREAD_MULTIPLE) {
-      xacc::warning("MPI_THREAD_MULTIPLE not provided.");
-    }
-    isMPIInitialized = 1;
-  }
-#endif
 }
 
 void setIsPyApi() { isPyApi = true; }
@@ -856,12 +835,6 @@ void Finalize() {
     compilation_database.clear();
     allocated_buffers.clear();
     xacc::ServiceAPI_Finalize();
-    // This replaces the HPC virtualization TearDown
-#ifdef MPI_ENABLED
-    if (isMPIInitialized) {
-      MPI_Finalize();
-    }
-#endif
   }
 }
 


### PR DESCRIPTION
A top-level MPI_Init at XACC Initialize() is not ideal since we may want to use an MPI-enabled backend (without HPC Virtualization) => a global MPI_Init is not ideal. Hence, move it back to within the scope of HPCVirt decorator.

Fixing a MPI_Finalize race condition issue when ExaTN MPI is present within the installation. ExaTN has `exatnInitializedMPI` variable to determine if it should do the MPI_Finalize step, hence HPC Virt should have the same mechanism to prevent HPC Virt from finalizing MPI pre-maturely and causing MPI errors during ExaTN Finalize() which could call MPI API's

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
